### PR TITLE
Only dispatch pointer events to active side

### DIFF
--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -104,7 +104,10 @@ class _FlipCardState extends State<FlipCard>
     } else {
       controller.reverse();
     }
-    isFront = !isFront;
+
+    setState(() {
+      isFront = !isFront;
+    });
   }
 
   @override
@@ -114,15 +117,21 @@ class _FlipCardState extends State<FlipCard>
       child: Stack(
         fit: StackFit.expand,
         children: <Widget>[
-          AnimationCard(
-            animation: _frontRotation,
-            child: widget.front,
-            direction: widget.direction,
+          AbsorbPointer(
+            absorbing: !isFront,
+            child: AnimationCard(
+              animation: _frontRotation,
+              child: widget.front,
+              direction: widget.direction,
+            ),
           ),
-          AnimationCard(
-            animation: _backRotation,
-            child: widget.back,
-            direction: widget.direction,
+          AbsorbPointer(
+            absorbing: isFront,
+            child: AnimationCard(
+              animation: _backRotation,
+              child: widget.back,
+              direction: widget.direction,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
Absorb pointer events that would reach the inactive side of a flipped card.

Fixes #1