### PR TITLE
Customize flip and background touch behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.0
+Added: Optional mode where the card can only be flipped programmatically
+
 # 0.2.2
 Added: Support speed params and expose call back when flip triggered
 Fixed: Absorb the event for Back side

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A component that provides flip card animation. It could be used for hide and sho
 import 'package:flip_card/flip_card.dart';
 ````
 
-Create a flip card
+Create a flip card. The card will flip when touched
 
 ```dart
 FlipCard(
@@ -26,5 +26,28 @@ FlipCard(
         child: Text('Back'),
     ),
 );
+```
+
+You can also configure the card to only flip when desired by using a `GlobalKey` to manage
+toggle the cards:
+```dart
+GlobalKey<FlipCardState> cardKey = GlobalKey<FlipCardState>();
+
+@override
+Widget build(BuildContext context) {
+  return FlipCard(
+    key: cardKey,
+    flipOnTouch: false,
+    front: Container(
+      child: RaisedButton(
+        onPressed: () => cardKey.currentState.toggleCard(),
+        child: Text('Toggle'),
+      ),
+    ),
+    back: Container(
+      child: Text('Back'),
+    ),
+  );
+}
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FlipCard(
 );
 ```
 
-You can also configure the card to only flip when desired by using a `GlobalKey` to manage
+You can also configure the card to only flip when desired by using a `GlobalKey` to
 toggle the cards:
 ```dart
 GlobalKey<FlipCardState> cardKey = GlobalKey<FlipCardState>();

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -47,14 +47,6 @@ class FlipCard extends StatefulWidget {
   final FlipDirection direction;
   final VoidCallback onFlip;
 
-  /// When set to true, touch events that would reach the "background" of the
-  /// flip card (e.g. the side that is not currently shown), are blocked. When
-  /// set to false, the card will be transparent to touch events, meaning that
-  /// a user can still touch buttons on the background of the card, although
-  /// they are invisible.
-  /// Defaults to true.
-  final bool blockInactiveInteractions;
-
   /// When enabled, the card will flip automatically when touched. This behavior
   /// can be disabled if this is not desired. To manually flip a card from your
   /// code, you could do this:
@@ -87,7 +79,6 @@ class FlipCard extends StatefulWidget {
       this.speed = 500,
       this.onFlip,
       this.direction = FlipDirection.HORIZONTAL,
-      this.blockInactiveInteractions = true,
       this.flipOnTouch = true})
       : super(key: key);
 
@@ -175,23 +166,18 @@ class FlipCardState extends State<FlipCard>
   }
 
   Widget _buildContent({@required bool front}) {
-    final card = AnimationCard(
-      animation: front ? _frontRotation : _backRotation,
-      child: front ? widget.front : widget.back,
-      direction: widget.direction,
+    // pointer events that would reach the backside of the card should be
+    // ignored
+    return IgnorePointer(
+      // absorb the front card when the background is active (!isFront),
+      // absorb the background when the front is active
+      ignoring: front ? !isFront : isFront,
+      child: AnimationCard(
+        animation: front ? _frontRotation : _backRotation,
+        child: front ? widget.front : widget.back,
+        direction: widget.direction,
+      ),
     );
-
-    // if we need to block background interactions, just ignore incoming pointer
-    // events for the subtree
-    if (widget.blockInactiveInteractions) {
-      return IgnorePointer(
-        // absorb the front card when the background is active (!isFront),
-        // absorb the background when the front is active
-        ignoring: front ? !isFront : isFront,
-        child: card,
-      );
-    }
-    return card;
   }
 
   @override

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -42,7 +42,7 @@ class FlipCard extends StatefulWidget {
   final Widget front;
   final Widget back;
 
-  /// The amount of milliseconds a turn operation will take.
+  /// The amount of milliseconds a turn animation will take.
   final int speed;
   final FlipDirection direction;
   final VoidCallback onFlip;
@@ -58,7 +58,26 @@ class FlipCard extends StatefulWidget {
   /// When enabled, the card will flip automatically when touched. This behavior
   /// can be disabled if this is not desired. To manually flip a card from your
   /// code, you could do this:
+  ///```dart
+  /// GlobalKey<FlipCardState> cardKey = GlobalKey<FlipCardState>();
   ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return FlipCard(
+  ///     key: cardKey,
+  ///     flipOnTouch: false,
+  ///     front: Container(
+  ///       child: RaisedButton(
+  ///         onPressed: () => cardKey.currentState.toggleCard(),
+  ///         child: Text('Toggle'),
+  ///       ),
+  ///     ),
+  ///     back: Container(
+  ///       child: Text('Back'),
+  ///     ),
+  ///   );
+  /// }
+  ///```
   final bool flipOnTouch;
 
   const FlipCard(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flip_card
 description: A component that provides flip card animation. It could be used for hide and show details of a product.
-version: 0.2.2
+version: 0.3.0
 author: fedeoo <fedeoo.zf@gmail.com>
 homepage: https://github.com/fedeoo/flip_card/
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -31,47 +31,26 @@ void main() {
     await tester.tap(find.byType(Stack));
   });
 
-  group('background interactions', () {
-    testWidgets('are blocked by default', (WidgetTester tester) async {
-      // check that background touches are blocked
-      bool backgroundTouched = false;
+  testWidgets('background interactions are ignored',
+      (WidgetTester tester) async {
+    // check that background touches are blocked
+    bool backgroundTouched = false;
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: new FlipCard(
-            front: Text('front'),
-            back: RaisedButton(
-              onPressed: () => backgroundTouched = true,
-              child: Text('back'),
-            ),
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: new FlipCard(
+          front: Text('front'),
+          back: RaisedButton(
+            onPressed: () => backgroundTouched = true,
+            child: Text('back'),
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.byType(RaisedButton));
-      expect(backgroundTouched, false);
-    });
-
-    testWidgets('can be turned on', (WidgetTester tester) async {
-      bool backgroundTouched = false;
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: new FlipCard(
-            front: Text('front'),
-            back: RaisedButton(
-              onPressed: () => backgroundTouched = true,
-              child: Text('back'),
-            ),
-            blockInactiveInteractions: false,
-          ),
-        ),
-      );
-
-      await tester.tap(find.byType(RaisedButton));
-      expect(backgroundTouched, true);
-    });
+    await tester.tap(find.byType(RaisedButton));
+    expect(backgroundTouched, false);
   });
 
   group('cards flip', () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,7 +3,6 @@
 // provides. For example, you can send tap and scroll gestures. You can also use WidgetTester to
 // find child widgets in the widget tree, read text, and verify that the values of widget properties
 // are correct.
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,25 +13,108 @@ void main() {
     // Build our app and trigger a frame.
     final frontKey = Key('front');
     final backKey = Key('back');
-    await tester.pumpWidget(new FlipCard(
-      front: Container(
-        key: frontKey,
-        child: Text('front'),
-      ),
-      back: Container(
-        key: backKey,
-        child: Text('back'),
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: new FlipCard(
+        front: Container(
+          key: frontKey,
+          child: Text('front'),
+        ),
+        back: Container(
+          key: backKey,
+          child: Text('back'),
+        ),
       ),
     ));
 
-    expect(
-      tester
-      .widgetList<Text>(find.byType(Text)),
-    equals(2));
+    expect(find.byType(Text), findsNWidgets(2));
+    await tester.tap(find.byType(Stack));
+  });
 
-    tester.tap(find.byType(Stack));
+  group('background interactions', () {
+    testWidgets('are blocked by default', (WidgetTester tester) async {
+      // check that background touches are blocked
+      bool backgroundTouched = false;
 
-    sleep(const Duration(seconds:1));
-    
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            front: Text('front'),
+            back: RaisedButton(
+              onPressed: () => backgroundTouched = true,
+              child: Text('back'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(RaisedButton));
+      expect(backgroundTouched, false);
+    });
+
+    testWidgets('can be turned on', (WidgetTester tester) async {
+      bool backgroundTouched = false;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            front: Text('front'),
+            back: RaisedButton(
+              onPressed: () => backgroundTouched = true,
+              child: Text('back'),
+            ),
+            blockInactiveInteractions: false,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(RaisedButton));
+      expect(backgroundTouched, true);
+    });
+  });
+
+  group('cards flip', () {
+    testWidgets('automatically', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            front: Text('front'),
+            back: Text('back'),
+          ),
+        ),
+      );
+      final state = tester.state<FlipCardState>(find.byType(FlipCard));
+
+      expect(state.isFront, isTrue);
+
+      await tester.tap(find.byType(FlipCard));
+      await tester.pumpAndSettle();
+
+      expect(state.isFront, isFalse);
+    });
+
+    testWidgets('manually', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            flipOnTouch: false,
+            front: Text('front'),
+            back: Text('back'),
+          ),
+        ),
+      );
+      final state = tester.state<FlipCardState>(find.byType(FlipCard));
+
+      await tester.tap(find.byType(FlipCard));
+      await tester.pumpAndSettle();
+      expect(state.isFront, true); // should not have turned by tapping
+
+      state.toggleCard();
+      await tester.pumpAndSettle();
+      expect(state.isFront, false);
+    });
   });
 }


### PR DESCRIPTION
As discussed in #7, this PR introduces an option to turn background touch-blocking off. It also allows users to implement a custom flip behavior that doesn't flip whenever the card is touched. I've added some tests and updated the readme accordingly.

Fixes #8 