### PR TITLE
fix wrong animation in flutter web

### DIFF
--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -21,7 +21,7 @@ class AnimationCard extends StatelessWidget {
       animation: animation,
       builder: (BuildContext context, Widget child) {
         var transform = Matrix4.identity();
-        transform.setEntry(3, 2, 0.001);
+        transform.setEntry(3, 2, 0.00001);
         if (direction == FlipDirection.VERTICAL) {
           transform.rotateX(animation.value);
         } else {


### PR DESCRIPTION
in flutter web the start of animation shows a small flipped card, and it is not erased. Changing the transform fixes the problem.

This is the wrong animation
![Screen Capture on 2019-11-05 at 10-20-09](https://user-images.githubusercontent.com/6496116/68211287-0e445200-ffb6-11e9-8856-883f607248ab.gif)

BTW, it works good in flutter desktop 👍 