### PR TITLE
Added controller. hint() to trigger UI hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ build/
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/flutter_export_environment.sh
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/

--- a/lib/flip_card.controller.dart
+++ b/lib/flip_card.controller.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flip_card/flip_card.dart';
+
+class FlipCardController {
+  /// The internal widget state.
+  /// Use only if you know what you're doing!
+  FlipCardState state;
+
+  /// The underlying AnimationController.
+  /// Use only if you know what you're doing!
+  AnimationController get controller => state?.controller;
+
+  /// Flip the card
+  void toggleCard() => state?.toggleCard();
+
+  /// Skew by amount percentage (0 - 1.0)
+  /// This can be used with a MouseReagion to indicate that the card can
+  /// be flipped. skew(0) to go back to original.
+  void skew(double amount, {Duration duration, Curve curve}) {
+    assert(0 <= amount && amount <= 1);
+
+    if (state.isFront) {
+      controller?.animateTo(amount, duration: duration, curve: curve);
+    } else {
+      controller?.animateTo(1 - amount, duration: duration, curve: curve);
+    }
+  }
+
+  /// Triggers a flip animation that reverses after the duration
+  /// and will run for `total`
+  void hint({Duration duration, Duration total}) {
+    assert(controller is AnimationController);
+    if (!(controller is AnimationController)) {
+      return;
+    }
+
+    if (controller.isAnimating || controller.value != 0) return;
+
+    Duration original = controller.duration;
+    controller.duration = total ?? controller.duration;
+    controller.forward();
+    Timer(duration ?? const Duration(milliseconds: 150), () {
+      controller.reverse();
+      controller.duration = original;
+    });
+  }
+}

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -1,6 +1,7 @@
 library flip_card;
 
 import 'dart:math';
+import 'package:flip_card/flip_card.controller.dart';
 import 'package:flutter/material.dart';
 
 enum FlipDirection {
@@ -49,6 +50,7 @@ class FlipCard extends StatefulWidget {
   final FlipDirection direction;
   final VoidCallback onFlip;
   final BoolCallback onFlipDone;
+  final FlipCardController controller;
 
   /// When enabled, the card will flip automatically when touched. This behavior
   /// can be disabled if this is not desired. To manually flip a card from your
@@ -83,6 +85,7 @@ class FlipCard extends StatefulWidget {
       this.onFlip,
       this.onFlipDone,
       this.direction = FlipDirection.HORIZONTAL,
+      this.controller,
       this.flipOnTouch = true})
       : super(key: key);
 
@@ -137,12 +140,16 @@ class FlipCardState extends State<FlipCard>
         if (widget.onFlipDone != null) widget.onFlipDone(isFront);
       }
     });
+
+    widget?.controller?.state = this;
   }
 
   void toggleCard() {
     if (widget.onFlip != null) {
       widget.onFlip();
     }
+
+    controller.duration = Duration(milliseconds: widget.speed);
     if (isFront) {
       controller.forward();
     } else {

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -77,17 +77,20 @@ class FlipCard extends StatefulWidget {
   ///```
   final bool flipOnTouch;
 
-  const FlipCard(
-      {Key key,
-      @required this.front,
-      @required this.back,
-      this.speed = 500,
-      this.onFlip,
-      this.onFlipDone,
-      this.direction = FlipDirection.HORIZONTAL,
-      this.controller,
-      this.flipOnTouch = true})
-      : super(key: key);
+  final Alignment alignment;
+
+  const FlipCard({
+    Key key,
+    @required this.front,
+    @required this.back,
+    this.speed = 500,
+    this.onFlip,
+    this.onFlipDone,
+    this.direction = FlipDirection.HORIZONTAL,
+    this.controller,
+    this.flipOnTouch = true,
+    this.alignment = Alignment.center,
+  }) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -164,6 +167,7 @@ class FlipCardState extends State<FlipCard>
   @override
   Widget build(BuildContext context) {
     final child = Stack(
+      alignment: widget.alignment,
       fit: StackFit.passthrough,
       children: <Widget>[
         _buildContent(front: true),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flip_card
 description: A component that provides flip card animation. It could be used for hide and show details of a product.
-version: 0.4.4
+version: 0.5.0
 author: fedeoo <fedeoo.zf@gmail.com>
 homepage: https://github.com/fedeoo/flip_card/
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flip_card
 description: A component that provides flip card animation. It could be used for hide and show details of a product.
-version: 0.5.0
+version: 0.5.1
 author: fedeoo <fedeoo.zf@gmail.com>
 homepage: https://github.com/fedeoo/flip_card/
 


### PR DESCRIPTION
Fixes #32 

- Version bumped to 0.5.0

### Usage

 ```dart
 FlipCardController _controller = FlipCardController();
  
  _controller.hint(
    // optional
    duration: Duration(milliseconds: 400),
    // optional
    total: Duration(milliseconds: 900),
  );
  
  FlipCard(
    direction: FlipDirection.HORIZONTAL,
    controller: _controller,
    onFlip: () {
      //
    },
    back: Center(
      child: Container(
        child: ProjectFrontWidget(
          project: widget.project,
        ),
      ),
    ),
    front: Container(
      color: Colors.red,
      child: Center(
        child: ProjectBackWidget(
          project: widget.project,
        ),
      ),
    ),
  );
```

The duration will only run if not flipped yet and not already animating.
Animation runs for `duration` and reverses afterwards. The `total` duration will be used for this animation only and resets afterwards.