### PR TITLE
Add constructor option to build the card with the back face (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Create a flip card. The card will flip when touched
 FlipCard(
   fill: Fill.fillBack, // Fill the back side of the card to make in the same size as the front.
   direction: FlipDirection.HORIZONTAL, // default
+  side: CardSide.FRONT, // The side to initially display.
   front: Container(
-        child: Text('Front'),
-    ),
-    back: Container(
-        child: Text('Back'),
-    ),
+    child: Text('Front'),
+  ),
+  back: Container(
+    child: Text('Back'),
+  ),
 );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,6 +41,7 @@ class HomePage extends StatelessWidget {
       color: Color(0x00000000),
       child: FlipCard(
         direction: FlipDirection.HORIZONTAL,
+        side: CardSide.FRONT,
         speed: 1000,
         onFlipDone: (status) {
           print(status);

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -9,6 +9,11 @@ enum FlipDirection {
   HORIZONTAL,
 }
 
+enum CardSide {
+  FRONT,
+  BACK,
+}
+
 enum Fill { none, fillFront, fillBack }
 
 class AnimationCard extends StatelessWidget {
@@ -54,6 +59,7 @@ class FlipCard extends StatefulWidget {
   final BoolCallback? onFlipDone;
   final FlipCardController? controller;
   final Fill fill;
+  final CardSide side;
 
   /// When enabled, the card will flip automatically when touched. This behavior
   /// can be disabled if this is not desired. To manually flip a card from your
@@ -94,26 +100,31 @@ class FlipCard extends StatefulWidget {
     this.flipOnTouch = true,
     this.alignment = Alignment.center,
     this.fill = Fill.none,
+    this.side = CardSide.FRONT,
   }) : super(key: key);
 
   @override
   State<StatefulWidget> createState() {
-    return FlipCardState();
+    return FlipCardState(this.side == CardSide.FRONT);
   }
 }
 
 class FlipCardState extends State<FlipCard>
     with SingleTickerProviderStateMixin {
+
   AnimationController? controller;
   Animation<double>? _frontRotation;
   Animation<double>? _backRotation;
 
-  bool isFront = true;
+  bool isFront;
+
+  FlipCardState(this.isFront);
 
   @override
   void initState() {
     super.initState();
     controller = AnimationController(
+        value: isFront ? 0.0 : 1.0,
         duration: Duration(milliseconds: widget.speed), vsync: this);
     _frontRotation = TweenSequence(
       [

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -53,6 +53,27 @@ void main() {
     expect(backgroundTouched, false);
   });
 
+  testWidgets('card initialized with back side', (WidgetTester tester) async {
+     await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            front: Text('front'),
+            back: Text('back'),
+            side: CardSide.BACK,
+          ),
+        ),
+      );
+      final state = tester.state<FlipCardState>(find.byType(FlipCard));
+
+      expect(state.isFront, isFalse);
+
+      await tester.tap(find.byType(FlipCard));
+      await tester.pumpAndSettle();
+
+      expect(state.isFront, isTrue);
+  });
+
   group('cards flip', () {
     testWidgets('automatically', (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
# Description

Fixes #24.

Add a new `side` constructor argument so back side of the card can be initially displayed instead of front.

I added a new `CardSide` enum so user can decide which is the initial side.
Please let me know if you prefer the feature to be implemented otherwise.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Self Code Review
- [ ] Tested on example project

Sorry I didn't have time to test it extensively. I just created a basic app and briefly checked the card was correctly built from back side and properly flipped. Hopefully there isn't any edge case I'm not aware of. :)

I also tried to add a unit test for what it's worth (it does not verify the animation is correct). 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Changed the example project to contain the new feature (only if applies)
