### PR TITLE
Added autoFlipDuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,19 @@ void doStuff() {
   _controller.toggleCard();
 }
 ```
+
+You can auto-flip the widget after a certain delay without any external triggering.
+```dart
+FlipCard(
+  fill: Fill.fillBack, // Fill the back side of the card to make in the same size as the front.
+  direction: FlipDirection.HORIZONTAL, // default
+  side: CardSide.FRONT, // The side to initially display.
+  front: Container(
+    child: Text('Front'),
+  ),
+  back: Container(
+    child: Text('Back'),
+  ),
+  autoFlipDuration: const Duration(seconds: 2), // The flip effect will work automatically after the 2 seconds
+);
+```

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -60,6 +60,8 @@ class FlipCard extends StatefulWidget {
   final FlipCardController? controller;
   final Fill fill;
   final CardSide side;
+
+  /// If the value is set, the flip effect will work automatically after the specified duration.
   final Duration? autoFlipDuration;
 
   /// When enabled, the card will flip automatically when touched. This behavior

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -161,7 +161,7 @@ class FlipCardState extends State<FlipCard>
     widget.controller?.state = this;
 
     if (widget.autoFlipDuration != null) {
-      Future.delayed(widget.autoFlipDuration!, () => toggleCard());
+      Future.delayed(widget.autoFlipDuration!, toggleCard);
     }
   }
 

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -102,7 +102,7 @@ class FlipCard extends StatefulWidget {
     this.alignment = Alignment.center,
     this.fill = Fill.none,
     this.side = CardSide.FRONT,
-    this.autoFlipDuration = const Duration(seconds: 1000),
+    this.autoFlipDuration,
   }) : super(key: key);
 
   @override

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -60,6 +60,7 @@ class FlipCard extends StatefulWidget {
   final FlipCardController? controller;
   final Fill fill;
   final CardSide side;
+  final Duration? autoFlipDuration;
 
   /// When enabled, the card will flip automatically when touched. This behavior
   /// can be disabled if this is not desired. To manually flip a card from your
@@ -101,6 +102,7 @@ class FlipCard extends StatefulWidget {
     this.alignment = Alignment.center,
     this.fill = Fill.none,
     this.side = CardSide.FRONT,
+    this.autoFlipDuration = const Duration(seconds: 1000),
   }) : super(key: key);
 
   @override
@@ -155,6 +157,10 @@ class FlipCardState extends State<FlipCard>
     ).animate(controller!);
 
     widget.controller?.state = this;
+
+    if (widget.autoFlipDuration != null) {
+      Future.delayed(widget.autoFlipDuration!, () => toggleCard());
+    }
   }
 
   /// Flip the card


### PR DESCRIPTION
# Description

Added one-time autoFlip feature without a FlipCardController. For example, a one-time flip can be played for the logo or the cards that need to be loaded once.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested it on my own project. The following parameter should be added to the FlipCard widget.

` autoFlipDuration: Duration(milliseconds: 1000),`

- [x] Self Code Review
- [x] Tested on example project


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Changed the example project to contain the new feature (only if applies)
