### PR TITLE
Added function to controller to instantly flip the card

### DIFF
--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -178,18 +178,18 @@ class FlipCardState extends State<FlipCard>
     });
   }
 
-  /// Flip the card without playing an animation
+  /// Flip the card without playing an animation.
+  /// This cancels any ongoing animation.
   void toggleCardWithoutAnimation() {
+    controller!.stop();
+
     widget.onFlip?.call();
 
-    final isFrontBefore = isFront;
-    controller!.duration = Duration(milliseconds: 0);
+    if (widget.onFlipDone != null) widget.onFlipDone!(isFront);
 
-    final animation = isFront ? controller!.forward() : controller!.reverse();
-    animation.whenComplete(() {
-      if (widget.onFlipDone != null) widget.onFlipDone!(isFront);
-      if (!mounted) return;
-      setState(() => isFront = !isFrontBefore);
+    setState(() {
+      isFront = !isFront;
+      controller!.value = isFront ? 0.0 : 1.0;
     });
   }
 

--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -178,6 +178,21 @@ class FlipCardState extends State<FlipCard>
     });
   }
 
+  /// Flip the card without playing an animation
+  void toggleCardWithoutAnimation() {
+    widget.onFlip?.call();
+
+    final isFrontBefore = isFront;
+    controller!.duration = Duration(milliseconds: 0);
+
+    final animation = isFront ? controller!.forward() : controller!.reverse();
+    animation.whenComplete(() {
+      if (widget.onFlipDone != null) widget.onFlipDone!(isFront);
+      if (!mounted) return;
+      setState(() => isFront = !isFrontBefore);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final frontPositioning = widget.fill == Fill.fillFront ? _fill : _noop;

--- a/lib/flip_card_controller.dart
+++ b/lib/flip_card_controller.dart
@@ -20,6 +20,9 @@ class FlipCardController {
   /// If awaited, returns after animation completes.
   Future<void> toggleCard() async => await state?.toggleCard();
 
+  /// Flip the card
+  void toggleCardWithoutAnimation() => state?.toggleCardWithoutAnimation();
+
   /// Skew by amount percentage (0 - 1.0)
   /// This can be used with a MouseReagion to indicate that the card can
   /// be flipped. skew(0) to go back to original.

--- a/lib/flip_card_controller.dart
+++ b/lib/flip_card_controller.dart
@@ -20,7 +20,8 @@ class FlipCardController {
   /// If awaited, returns after animation completes.
   Future<void> toggleCard() async => await state?.toggleCard();
 
-  /// Flip the card
+  /// Flip the card without playing an animation.
+  /// This cancels any ongoing animation.
   void toggleCardWithoutAnimation() => state?.toggleCardWithoutAnimation();
 
   /// Skew by amount percentage (0 - 1.0)

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -157,7 +157,7 @@ void main() {
       );
 
       controller.toggleCardWithoutAnimation();
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(controller.state?.isFront, false);
     });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -139,6 +139,28 @@ void main() {
 
       expect(controller.state?.isFront, false);
     });
+
+    testWidgets('manually via controller without animation',
+        (WidgetTester tester) async {
+      final controller = FlipCardController();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: new FlipCard(
+            controller: controller,
+            flipOnTouch: false,
+            front: Text('front'),
+            back: Text('back'),
+          ),
+        ),
+      );
+
+      controller.toggleCardWithoutAnimation();
+      await tester.pumpAndSettle();
+
+      expect(controller.state?.isFront, false);
+    });
   });
 
   group('skew', () {


### PR DESCRIPTION
# Description

Added function ```toggleCardWithoutAnimation``` to the controller that toggles the card instantly.
It is implemented in the same way as the regular ```toggleCard``` function.

There might be a better way to implement this feature. It didn't seem to work by simply calling setState with ```isFront``` toggled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added a new test that validates the function in the same as the regular ```toggleCard``` function.
I have also tested it in my own project.

- [x] Self Code Review
- [x] Tested on example project

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Changed the example project to contain the new feature (only if applies)
