### PR TITLE
[Fix] Toggle/Start the animation only when the widget is mounted

### DIFF
--- a/lib/flip_card.dart
+++ b/lib/flip_card.dart
@@ -173,6 +173,8 @@ class FlipCardState extends State<FlipCard>
   /// Flip the card
   /// If awaited, returns after animation completes.
   Future<void> toggleCard() async {
+    if(!mounted) return;
+    
     widget.onFlip?.call();
 
     final isFrontBefore = isFront;


### PR DESCRIPTION
# Description

When we use the automatic flip ON and we close the screen, this will throw an exception because the widget is not mounted and we try to forward the animation controller.

```
 if (widget.autoFlipDuration != null) {
      Future.delayed(widget.autoFlipDuration!, toggleCard);
    }
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Self Code Review
- [x] Tested on example project


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Changed the example project to contain the new feature (only if applies)
