### PR TITLE
remove artifacts

### DIFF
--- a/lib/src/flip_card_transition.dart
+++ b/lib/src/flip_card_transition.dart
@@ -191,7 +191,7 @@ class FlipTransition extends AnimatedWidget {
   @override
   Widget build(BuildContext context) {
     final transform = Matrix4.identity();
-    transform.setEntry(3, 2, 0.001);
+    transform.setEntry(3, 2, 0);
     switch (direction) {
       case Axis.horizontal:
         transform.rotateY(animation.value);


### PR DESCRIPTION
# Description

I noticed that occasionally that there were slices/artifacts showing the back of cards on the screen. Example: 

![Screenshot from 2024-12-13 22-24-33](https://github.com/user-attachments/assets/7885236d-837d-4109-b094-bd1f4a9f1111)

Changing the transform value to 0 fixed this for me. 

Fixes #79, maybe #73

## Type of change

- [ :heavy_check_mark: ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ :heavy_check_mark:  ] Tested on example project
